### PR TITLE
Feat/delete mlp older than datetime implementation

### DIFF
--- a/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
+++ b/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
@@ -611,5 +611,17 @@ namespace HucaresServer.Storage.UnitTests
                 startDateTime: new DateTime(2018, 10, 05), endDateTime: new DateTime(2018, 09, 05)));
             A.CallTo(() => fakeDbContextFactory.BuildHucaresContext()).MustNotHaveHappened();
         }
+
+        [Test]
+        public void DeletePlatesOlderThanDatetime_WithCorrectDate_ShouldReturn()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Test]
+        public void DeletePlatesOlderThanDatetime_WithDateInFuture_ShouldThrow()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
+++ b/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
@@ -616,14 +616,15 @@ namespace HucaresServer.Storage.UnitTests
         public void DeletePlatesOlderThanDatetime_WithCorrectDate_ShouldReturn()
         {
             //Arrange 
-            var expectedDetectedLicensePlate = new DetectedLicensePlate()
+            var expectedRemainingDetectedLicensePlate = new DetectedLicensePlate()
                 {DetectedDateTime = new DateTime(2018, 10, 10)};
+            var expectedDeletedDetectedLicensePlate = new DetectedLicensePlate()
+                {DetectedDateTime = new DateTime(2018, 09, 10)};
             
             var fakeDetectedPlatesList = new List<DetectedLicensePlate>()
             {
-                expectedDetectedLicensePlate,
-                new DetectedLicensePlate() {DetectedDateTime = new DateTime(2018, 09, 10)},
-                new DetectedLicensePlate() {DetectedDateTime = new DateTime(2018, 08, 10)}
+                expectedRemainingDetectedLicensePlate,
+                expectedDeletedDetectedLicensePlate
             };
             
             var fakeDbSetDetectedPlates = StorageTestsUtil.SetupFakeDbSet(fakeDetectedPlatesList.AsQueryable());
@@ -640,12 +641,15 @@ namespace HucaresServer.Storage.UnitTests
             var detectedPlateHelper = new DetectedPlateHelper(fakeDbContextFactory, fakeMissingPlateHelper);
             
             //Act
-            var results = detectedPlateHelper.DeletePlatesOlderThanDatetime(new DateTime(2018, 10, 01)).ToList();
+            var deletedPlates = detectedPlateHelper.DeletePlatesOlderThanDatetime(new DateTime(2018, 10, 01)).ToList();
             
             //Assert
             A.CallTo(() => fakeHucaresContext.DetectedLicensePlates).MustHaveHappened();
-            results.Count.ShouldBe(1);
-            results.FirstOrDefault().ShouldBe(expectedDetectedLicensePlate);
+            deletedPlates.Count.ShouldBe(1);
+            deletedPlates.FirstOrDefault().ShouldBe(expectedDeletedDetectedLicensePlate);
+            
+            fakeHucaresContext.DetectedLicensePlates.FirstOrDefault()
+                .ShouldBe(expectedRemainingDetectedLicensePlate);
         }
 
         [Test]

--- a/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
+++ b/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
@@ -615,7 +615,37 @@ namespace HucaresServer.Storage.UnitTests
         [Test]
         public void DeletePlatesOlderThanDatetime_WithCorrectDate_ShouldReturn()
         {
-            throw new NotImplementedException();
+            //Arrange 
+            var expectedDetectedLicensePlate = new DetectedLicensePlate()
+                {DetectedDateTime = new DateTime(2018, 10, 10)};
+            
+            var fakeDetectedPlatesList = new List<DetectedLicensePlate>()
+            {
+                expectedDetectedLicensePlate,
+                new DetectedLicensePlate() {DetectedDateTime = new DateTime(2018, 09, 10)},
+                new DetectedLicensePlate() {DetectedDateTime = new DateTime(2018, 08, 10)}
+            };
+            
+            var fakeDbSetDetectedPlates = StorageTestsUtil.SetupFakeDbSet(fakeDetectedPlatesList.AsQueryable());
+            
+            var fakeHucaresContext = A.Fake<HucaresContext>();
+            var fakeDbContextFactory = A.Fake<IDbContextFactory>();
+            A.CallTo(() => fakeDbContextFactory.BuildHucaresContext())
+                .Returns(fakeHucaresContext);
+
+            A.CallTo(() => fakeHucaresContext.DetectedLicensePlates)
+                .Returns(fakeDbSetDetectedPlates);
+            
+            var fakeMissingPlateHelper = A.Fake<IMissingPlateHelper>();
+            var detectedPlateHelper = new DetectedPlateHelper(fakeDbContextFactory, fakeMissingPlateHelper);
+            
+            //Act
+            var results = detectedPlateHelper.DeletePlatesOlderThanDatetime(new DateTime(2018, 10, 01)).ToList();
+            
+            //Assert
+            A.CallTo(() => fakeHucaresContext.DetectedLicensePlates).MustHaveHappened();
+            results.Count.ShouldBe(1);
+            results.FirstOrDefault().ShouldBe(expectedDetectedLicensePlate);
         }
 
         [Test]

--- a/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
+++ b/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
@@ -617,9 +617,9 @@ namespace HucaresServer.Storage.UnitTests
         {
             //Arrange 
             var expectedRemainingDetectedLicensePlate = new DetectedLicensePlate()
-                {DetectedDateTime = new DateTime(2018, 10, 10)};
+                {DetectedDateTime = new DateTime(2018, 10, 10), PlateNumber = "ABC123"};
             var expectedDeletedDetectedLicensePlate = new DetectedLicensePlate()
-                {DetectedDateTime = new DateTime(2018, 09, 10)};
+                {DetectedDateTime = new DateTime(2018, 09, 10), PlateNumber = "ABC123"};
             
             var fakeDetectedPlatesList = new List<DetectedLicensePlate>()
             {
@@ -638,6 +638,9 @@ namespace HucaresServer.Storage.UnitTests
                 .Returns(fakeDbSetDetectedPlates);
             
             var fakeMissingPlateHelper = A.Fake<IMissingPlateHelper>();
+            A.CallTo(() => fakeMissingPlateHelper.GetAllPlateRecords())
+                .Returns(new List<MissingLicensePlate>());
+            
             var detectedPlateHelper = new DetectedPlateHelper(fakeDbContextFactory, fakeMissingPlateHelper);
             
             //Act

--- a/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
+++ b/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
@@ -651,7 +651,18 @@ namespace HucaresServer.Storage.UnitTests
         [Test]
         public void DeletePlatesOlderThanDatetime_WithDateInFuture_ShouldThrow()
         {
-            throw new NotImplementedException();
+            //Arrange         
+            var fakeHucaresContext = A.Fake<HucaresContext>();
+            var fakeDbContextFactory = A.Fake<IDbContextFactory>();
+            A.CallTo(() => fakeDbContextFactory.BuildHucaresContext())
+                .Returns(fakeHucaresContext);
+
+            var fakeMissingPlateHelper = A.Fake<IMissingPlateHelper>();
+            var detectedPlateHelper = new DetectedPlateHelper(fakeDbContextFactory, fakeMissingPlateHelper);
+            
+            //Act & assert
+            Assert.Throws<ArgumentException>(() => detectedPlateHelper.DeletePlatesOlderThanDatetime(DateTime.Today.AddDays(2)));
+            A.CallTo(() => fakeDbContextFactory.BuildHucaresContext()).MustNotHaveHappened();
         }
     }
 }

--- a/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
+++ b/src/HucaresServer.Storage.UnitTests/DetectedPlateHelperTests.cs
@@ -613,7 +613,7 @@ namespace HucaresServer.Storage.UnitTests
         }
 
         [Test]
-        public void DeletePlatesOlderThanDatetime_WithCorrectDate_ShouldReturn()
+        public void DeletePlatesOlderThanDatetime_WithCorrectDateNoMissingNumbers_ShouldReturn()
         {
             //Arrange 
             var expectedRemainingDetectedLicensePlate = new DetectedLicensePlate()
@@ -656,6 +656,54 @@ namespace HucaresServer.Storage.UnitTests
         }
 
         [Test]
+        public void DeletePlatesOlderThanDatetime_WithCorrectDateWithMissingNumber_ShouldReturn()
+        {
+            //Arrange 
+            var expectedRemainingDetectedLicensePlate = new DetectedLicensePlate()
+                {DetectedDateTime = new DateTime(2018, 09, 10), PlateNumber = "FFF999"};
+            var expectedDeletedDetectedLicensePlate = new DetectedLicensePlate()
+                {DetectedDateTime = new DateTime(2018, 09, 10), PlateNumber = "ABC123"};
+            
+            var fakeDetectedPlatesList = new List<DetectedLicensePlate>()
+            {
+                expectedRemainingDetectedLicensePlate,
+                expectedDeletedDetectedLicensePlate
+            };
+            
+            var fakeDbSetDetectedPlates = StorageTestsUtil.SetupFakeDbSet(fakeDetectedPlatesList.AsQueryable());
+            
+            var fakeHucaresContext = A.Fake<HucaresContext>();
+            var fakeDbContextFactory = A.Fake<IDbContextFactory>();
+            A.CallTo(() => fakeDbContextFactory.BuildHucaresContext())
+                .Returns(fakeHucaresContext);
+
+            A.CallTo(() => fakeHucaresContext.DetectedLicensePlates)
+                .Returns(fakeDbSetDetectedPlates);
+            
+            var fakeMissingPlateHelper = A.Fake<IMissingPlateHelper>();
+            A.CallTo(() => fakeMissingPlateHelper.GetAllPlateRecords())
+                .Returns(new List<MissingLicensePlate>()
+                {
+                    new MissingLicensePlate() {PlateNumber = expectedRemainingDetectedLicensePlate.PlateNumber}
+                });
+            
+            var detectedPlateHelper = new DetectedPlateHelper(fakeDbContextFactory, fakeMissingPlateHelper);
+            
+            //Act
+            var deletedPlates = detectedPlateHelper.DeletePlatesOlderThanDatetime(new DateTime(2018, 10, 01)).ToList();
+            
+            //Assert
+            A.CallTo(() => fakeHucaresContext.DetectedLicensePlates).MustHaveHappened();
+            A.CallTo(() => fakeMissingPlateHelper.GetAllPlateRecords()).MustHaveHappened();
+            
+            deletedPlates.Count.ShouldBe(1);
+            deletedPlates.FirstOrDefault().ShouldBe(expectedDeletedDetectedLicensePlate);
+            
+            fakeHucaresContext.DetectedLicensePlates.FirstOrDefault()
+                .ShouldBe(expectedRemainingDetectedLicensePlate);
+        }
+        
+        [Test]
         public void DeletePlatesOlderThanDatetime_WithDateInFuture_ShouldThrow()
         {
             //Arrange         
@@ -665,11 +713,15 @@ namespace HucaresServer.Storage.UnitTests
                 .Returns(fakeHucaresContext);
 
             var fakeMissingPlateHelper = A.Fake<IMissingPlateHelper>();
+            A.CallTo(() => fakeMissingPlateHelper.GetAllPlateRecords())
+                .Returns(new List<MissingLicensePlate>());
+            
             var detectedPlateHelper = new DetectedPlateHelper(fakeDbContextFactory, fakeMissingPlateHelper);
             
             //Act & assert
             Assert.Throws<ArgumentException>(() => detectedPlateHelper.DeletePlatesOlderThanDatetime(DateTime.Today.AddDays(2)));
             A.CallTo(() => fakeDbContextFactory.BuildHucaresContext()).MustNotHaveHappened();
+            A.CallTo(() => fakeMissingPlateHelper.GetAllPlateRecords()).MustNotHaveHappened();
         }
     }
 }

--- a/src/HucaresServer.Storage/Helpers/DetectedPlateHelper.cs
+++ b/src/HucaresServer.Storage/Helpers/DetectedPlateHelper.cs
@@ -63,9 +63,13 @@ namespace HucaresServer.Storage.Helpers
                 throw new ArgumentException(string.Format($"Provided datetime cannot be in the future ({olderThanDatetime})"));
             }
 
+            var missingPlates = _missingPlateHelper.GetAllPlateRecords()
+                .Select(s => s.PlateNumber);
+            
             using (var ctx = _dbContextFactory.BuildHucaresContext())
             {
-                var platesToDelete = ctx.DetectedLicensePlates.Where(s => s.DetectedDateTime < olderThanDatetime).ToList();
+                var platesToDelete = ctx.DetectedLicensePlates.Where(s => s.DetectedDateTime < olderThanDatetime &&
+                                                                          !missingPlates.Contains(s.PlateNumber)).ToList();
                 ctx.DetectedLicensePlates.RemoveRange(platesToDelete);
                 ctx.SaveChanges();
 

--- a/src/HucaresServer.Storage/Helpers/DetectedPlateHelper.cs
+++ b/src/HucaresServer.Storage/Helpers/DetectedPlateHelper.cs
@@ -58,7 +58,19 @@ namespace HucaresServer.Storage.Helpers
 
         public IEnumerable<DetectedLicensePlate> DeletePlatesOlderThanDatetime(DateTime olderThanDatetime)
         {
-            throw new NotImplementedException();
+            if (olderThanDatetime > DateTime.Today)
+            {
+                throw new ArgumentException(string.Format($"Provided datetime cannot be in the future ({olderThanDatetime})"));
+            }
+
+            using (var ctx = _dbContextFactory.BuildHucaresContext())
+            {
+                var platesToDelete = ctx.DetectedLicensePlates.Where(s => s.DetectedDateTime < olderThanDatetime);
+                var deletedPlates = ctx.DetectedLicensePlates.RemoveRange(platesToDelete).ToList();
+                ctx.SaveChanges();
+
+                return deletedPlates;
+            }
         }
         
         ///<inheritdoc/>

--- a/src/HucaresServer.Storage/Helpers/DetectedPlateHelper.cs
+++ b/src/HucaresServer.Storage/Helpers/DetectedPlateHelper.cs
@@ -65,11 +65,11 @@ namespace HucaresServer.Storage.Helpers
 
             using (var ctx = _dbContextFactory.BuildHucaresContext())
             {
-                var platesToDelete = ctx.DetectedLicensePlates.Where(s => s.DetectedDateTime < olderThanDatetime);
-                var deletedPlates = ctx.DetectedLicensePlates.RemoveRange(platesToDelete).ToList();
+                var platesToDelete = ctx.DetectedLicensePlates.Where(s => s.DetectedDateTime < olderThanDatetime).ToList();
+                ctx.DetectedLicensePlates.RemoveRange(platesToDelete);
                 ctx.SaveChanges();
 
-                return deletedPlates;
+                return platesToDelete;
             }
         }
         


### PR DESCRIPTION
Added last helper method for DetectedLicensePlateHelper (DeletePlatesOlderThanDatetime) and two tests to accompany it.